### PR TITLE
In some cases apt could write generated file which was already writte…

### DIFF
--- a/jackson-apt-processor/src/main/java/org/dominokit/jacksonapt/processor/DeserializerGenerator.java
+++ b/jackson-apt-processor/src/main/java/org/dominokit/jacksonapt/processor/DeserializerGenerator.java
@@ -3,6 +3,7 @@ package org.dominokit.jacksonapt.processor;
 import com.squareup.javapoet.ClassName;
 import org.dominokit.jacksonapt.processor.deserialization.AptDeserializerBuilder;
 
+import javax.annotation.processing.FilerException;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
@@ -33,11 +34,13 @@ public class DeserializerGenerator {
 
         if (!TypeRegistry.containsDeserializer(Type.stringifyTypeWithPackage(beanType))) {
             try {
-            	generateSubTypesDeserializers(beanType, packageName);
+                generateSubTypesDeserializers(beanType, packageName);
                 TypeRegistry.addInActiveGenDeserializer(beanType);
                 new AptDeserializerBuilder(packageName, beanType, filer).generate();
                 TypeRegistry.registerDeserializer(Type.stringifyTypeWithPackage(beanType), ClassName.bestGuess(deserializerName));
                 TypeRegistry.removeInActiveGenDeserializer(beanType);
+            } catch (FilerException e) {
+                //should be skipped
             } catch (IOException e) {
                 throw new DeserializerGenerator.DeserializerGenerationFailedException(beanType.toString());
             }

--- a/jackson-apt-processor/src/main/java/org/dominokit/jacksonapt/processor/SerializerGenerator.java
+++ b/jackson-apt-processor/src/main/java/org/dominokit/jacksonapt/processor/SerializerGenerator.java
@@ -3,6 +3,7 @@ package org.dominokit.jacksonapt.processor;
 import com.squareup.javapoet.ClassName;
 import org.dominokit.jacksonapt.processor.serialization.AptSerializerBuilder;
 
+import javax.annotation.processing.FilerException;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
@@ -37,6 +38,8 @@ public class SerializerGenerator {
                 new AptSerializerBuilder(packageName, beanType, ObjectMapperProcessor.filer).generate();
                 TypeRegistry.registerSerializer(Type.stringifyTypeWithPackage(beanType), ClassName.bestGuess(serializerName));
                 TypeRegistry.removeInActiveGenSerializer(beanType);
+            } catch (FilerException e) {
+                //should be skipped
             } catch (IOException e) {
                 throw new SerializerGenerationFailedException(beanType.toString());
             }


### PR DESCRIPTION
…n and it leads to FilerException.

This exception could be skipped.