### PR TITLE
in some cases typeParameters.size > typeArguments.size which leads to…

### DIFF
--- a/jackson-apt-processor/src/main/java/org/dominokit/jacksonapt/processor/AbstractJsonMapperGenerator.java
+++ b/jackson-apt-processor/src/main/java/org/dominokit/jacksonapt/processor/AbstractJsonMapperGenerator.java
@@ -188,7 +188,7 @@ public abstract class AbstractJsonMapperGenerator {
         List<? extends TypeParameterElement> typeParameters = enclosingElement.getTypeParameters();
         List<? extends TypeMirror> typeArguments = enclosingType.getTypeArguments();
         final Map<? extends TypeParameterElement, ? extends TypeMirror> typeParameterMap =
-                IntStream.range(0, typeParameters.size())
+                IntStream.range(0, typeArguments.size())
                         .boxed()
                         .collect(Collectors.toMap(typeParameters::get, typeArguments::get));
 


### PR DESCRIPTION
… IndexOutOfBoundsException

reproducer: https://github.com/treblereel/j2cl-tests/tree/typeArguments