### PR TITLE
serialize NaN and +/-Infinity as strings in lenient mode

### DIFF
--- a/domino-jackson/src/main/java/org/dominokit/jackson/stream/impl/DefaultJsonWriter.java
+++ b/domino-jackson/src/main/java/org/dominokit/jackson/stream/impl/DefaultJsonWriter.java
@@ -433,12 +433,17 @@ public class DefaultJsonWriter implements JsonWriter {
   /** {@inheritDoc} */
   @Override
   public DefaultJsonWriter value(double value) {
-    if (Double.isNaN(value) || Double.isInfinite(value)) {
+    final boolean isNaNorInfinity = Double.isNaN(value) || Double.isInfinite(value);
+    if (!lenient && isNaNorInfinity) {
       throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
     }
     writeDeferredName();
     beforeValue(false);
-    out.append(value);
+    if (isNaNorInfinity) {
+      string(Double.toString(value));
+    } else {
+      out.append(value);
+    }
     return this;
   }
 

--- a/domino-jackson/src/main/java/org/dominokit/jackson/stream/impl/FastJsonWriter.java
+++ b/domino-jackson/src/main/java/org/dominokit/jackson/stream/impl/FastJsonWriter.java
@@ -301,12 +301,17 @@ public class FastJsonWriter implements JsonWriter {
   /** {@inheritDoc} */
   @Override
   public FastJsonWriter value(double value) {
-    if (Double.isNaN(value) || Double.isInfinite(value)) {
+    final boolean isNaNorInfinity = Double.isNaN(value) || Double.isInfinite(value);
+    if (!lenient && isNaNorInfinity) {
       throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
     }
     writeDeferredName();
     beforeValue(false);
-    out.append(value);
+    if (isNaNorInfinity) {
+      string(Double.toString(value));
+    } else {
+      out.append(value);
+    }
     return this;
   }
 

--- a/domino-jackson/src/test/java/org/dominokit/jackson/client/deser/number/DoubleJsonDeserializerTest.java
+++ b/domino-jackson/src/test/java/org/dominokit/jackson/client/deser/number/DoubleJsonDeserializerTest.java
@@ -34,5 +34,7 @@ public class DoubleJsonDeserializerTest extends AbstractJsonDeserializerTest<Dou
     assertDeserialization(-784.15454d, "\"-784.15454\"");
     assertDeserialization(Double.MIN_VALUE, "4.9E-324");
     assertDeserialization(Double.MAX_VALUE, "1.7976931348623157e+308");
+    assertDeserialization(Double.NaN, "\"NaN\"");
+    assertDeserialization(Double.NEGATIVE_INFINITY, "\"-Infinity\"");
   }
 }

--- a/domino-jackson/src/test/java/org/dominokit/jackson/client/deser/number/DoubleJsonDeserializerTest.java
+++ b/domino-jackson/src/test/java/org/dominokit/jackson/client/deser/number/DoubleJsonDeserializerTest.java
@@ -34,7 +34,7 @@ public class DoubleJsonDeserializerTest extends AbstractJsonDeserializerTest<Dou
     assertDeserialization(-784.15454d, "\"-784.15454\"");
     assertDeserialization(Double.MIN_VALUE, "4.9E-324");
     assertDeserialization(Double.MAX_VALUE, "1.7976931348623157e+308");
-    assertDeserialization(Double.NaN, "\"NaN\"");
+    assertTrue(Double.isNaN(deserialize("\"NaN\"")));
     assertDeserialization(Double.NEGATIVE_INFINITY, "\"-Infinity\"");
   }
 }

--- a/domino-jackson/src/test/java/org/dominokit/jackson/client/ser/number/DoubleJsonSerializerTest.java
+++ b/domino-jackson/src/test/java/org/dominokit/jackson/client/ser/number/DoubleJsonSerializerTest.java
@@ -38,5 +38,7 @@ public class DoubleJsonSerializerTest extends AbstractJsonSerializerTest<Double>
             ? "1.7976931348623157e+308"
             : "1.7976931348623157E308"),
         Double.MAX_VALUE);
+    assertSerialization("\"NaN\"", Double.NaN);
+    assertSerialization("\"-Infinity\"", Double.NEGATIVE_INFINITY);
   }
 }

--- a/domino-jackson/src/test/java/org/dominokit/jackson/server/deser/number/DoubleJsonDeserializerTest.java
+++ b/domino-jackson/src/test/java/org/dominokit/jackson/server/deser/number/DoubleJsonDeserializerTest.java
@@ -36,7 +36,7 @@ public class DoubleJsonDeserializerTest extends AbstractJsonDeserializerTest<Dou
     assertDeserialization(-784.15454d, "\"-784.15454\"");
     assertDeserialization(Double.MIN_VALUE, "4.9E-324");
     assertDeserialization(Double.MAX_VALUE, "1.7976931348623157e+308");
-    assertDeserialization(Double.NaN, "NaN");
+    assertTrue(Double.isNaN(deserialize("\"NaN\"")));
     assertDeserialization(Double.NEGATIVE_INFINITY, "-Infinity");
   }
 }

--- a/domino-jackson/src/test/java/org/dominokit/jackson/server/deser/number/DoubleJsonDeserializerTest.java
+++ b/domino-jackson/src/test/java/org/dominokit/jackson/server/deser/number/DoubleJsonDeserializerTest.java
@@ -16,6 +16,8 @@
 
 package org.dominokit.jackson.server.deser.number;
 
+import static org.junit.Assert.assertTrue;
+
 import org.dominokit.jackson.deser.BaseNumberJsonDeserializer.DoubleJsonDeserializer;
 import org.dominokit.jackson.server.deser.AbstractJsonDeserializerTest;
 import org.junit.Test;

--- a/domino-jackson/src/test/java/org/dominokit/jackson/server/deser/number/DoubleJsonDeserializerTest.java
+++ b/domino-jackson/src/test/java/org/dominokit/jackson/server/deser/number/DoubleJsonDeserializerTest.java
@@ -36,5 +36,7 @@ public class DoubleJsonDeserializerTest extends AbstractJsonDeserializerTest<Dou
     assertDeserialization(-784.15454d, "\"-784.15454\"");
     assertDeserialization(Double.MIN_VALUE, "4.9E-324");
     assertDeserialization(Double.MAX_VALUE, "1.7976931348623157e+308");
+    assertDeserialization(Double.NaN, "NaN");
+    assertDeserialization(Double.NEGATIVE_INFINITY, "-Infinity");
   }
 }

--- a/domino-jackson/src/test/java/org/dominokit/jackson/server/ser/number/DoubleJsonSerializerTest.java
+++ b/domino-jackson/src/test/java/org/dominokit/jackson/server/ser/number/DoubleJsonSerializerTest.java
@@ -34,5 +34,7 @@ public class DoubleJsonSerializerTest extends AbstractJsonSerializerTest<Double>
     assertSerialization("-784.15454", -784.15454d);
     assertSerialization("4.9E-324", Double.MIN_VALUE);
     assertSerialization("1.7976931348623157E308", Double.MAX_VALUE);
+    assertSerialization("\"NaN\"", Double.NaN);
+    assertSerialization("\"-Infinity\"", Double.NEGATIVE_INFINITY);
   }
 }


### PR DESCRIPTION
This is the rebased fix for #68 as stated in https://github.com/DominoKit/domino-jackson/pull/69.